### PR TITLE
Add RollingUpdate option

### DIFF
--- a/kubernetes/demo.yaml
+++ b/kubernetes/demo.yaml
@@ -9,6 +9,9 @@ spec:
   minReadySeconds: 30
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100% # maximum number of Pods that can be created above the desired number of Pods
+      maxUnavailable: 0 # maximum number of Pods that can be unavailable during the update process.
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
## REF
#9 
http://kubernetes.io/docs/user-guide/deployments/

## WHY

> Max Unavailable

> .spec.strategy.rollingUpdate.maxUnavailable is an optional field that specifies the maximum number of Pods that can be unavailable during the update process. The value can be an absolute number (e.g. 5) or a percentage of desired Pods (e.g. 10%). The absolute number is calculated from percentage by rounding up. This can not be 0 if .spec.strategy.rollingUpdate.maxSurge is 0. By default, a fixed value of 1 is used.

> For example, when this value is set to 30%, the old Replica Set can be scaled down to 70% of desired Pods immediately when the rolling update starts. Once new Pods are ready, old Replica Set can be scaled down further, followed by scaling up the new Replica Set, ensuring that the total number of Pods available at all times during the update is at least 70% of the desired Pods.

> Max Surge

> .spec.strategy.rollingUpdate.maxSurge is an optional field that specifies the maximum number of Pods that can be created above the desired number of Pods. Value can be an absolute number (e.g. 5) or a percentage of desired Pods (e.g. 10%). This can not be 0 if MaxUnavailable is 0. The absolute number is calculated from percentage by rounding up. By default, a value of 1 is used.

> For example, when this value is set to 30%, the new Replica Set can be scaled up immediately when the rolling update starts, such that the total number of old and new Pods do not exceed 130% of desired Pods. Once old Pods have been killed, the new Replica Set can be scaled up further, ensuring that the total number of Pods running at any time during the update is at most 130% of desired Pods.

## WHAT

setup option