### PR TITLE
Fix ci-build

### DIFF
--- a/script/ci-build
+++ b/script/ci-build
@@ -5,8 +5,8 @@ set -o pipefail
 
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
-echo "script/bootstrap"
-script/bootstrap
+echo "make install"
+make install
 
 echo "Testing..."
 make test


### PR DESCRIPTION
## WHY

Fix `make: bin/demo is up to date.`

